### PR TITLE
feat: add -T/--timestamps (env LOGPROXY_TIMESTAMPS) option to prepend strftime to each line

### DIFF
--- a/src/log_proxy.c
+++ b/src/log_proxy.c
@@ -114,7 +114,7 @@ static void every_second() {
             // another program rotated our log file
             // => let's reinit the output channel
             destroy_output_channel();
-            init_output_channel(log_file, use_locks, TRUE, chmod_str, chown_str, chgrp_str);
+            init_output_channel(log_file, use_locks, TRUE, chmod_str, chown_str, chgrp_str, timestamp_prefix);
             unlock_control_file(fd);
             return;
         }
@@ -141,7 +141,7 @@ static void every_second() {
             }
             if (rotate_res == TRUE) {
                 destroy_output_channel();
-                init_output_channel(log_file, use_locks, TRUE, chmod_str, chown_str, chgrp_str);
+                init_output_channel(log_file, use_locks, TRUE, chmod_str, chown_str, chgrp_str, timestamp_prefix);
             }
         }
         unlock_control_file(fd);
@@ -202,7 +202,7 @@ void init_or_reinit_output_channel(const gchar *lg_file, gboolean us_locks) {
         exit(2);
     }
     destroy_output_channel();
-    init_output_channel(lg_file, us_locks, FALSE, chmod_str, chown_str, chgrp_str);
+    init_output_channel(lg_file, us_locks, FALSE, chmod_str, chown_str, chgrp_str, timestamp_prefix);
     unlock_control_file(lock_fd);
 }
 
@@ -212,7 +212,7 @@ int main(int argc, char *argv[])
     setlocale(LC_ALL, "");
     context = g_option_context_new("LOGFILE  - log proxy");
     g_option_context_add_main_entries(context, entries, NULL);
-    gchar *description = "Optional environment variables to override defaults: \n    LOGPROXY_ROTATION_SIZE\n    LOGPROXY_ROTATION_TIME\n    LOGPROXY_ROTATION_SUFFIX\n    LOGPROXY_LOG_DIRECTORY\n    LOGPROXY_ROTATED_FILES\n\nExample for rotation-size option:\n- If log_proxy is run with the option --rotation-size on the command line, rotation-size will take the provided value\n- If the option --rotation-size is not provided on command line :\n  - If the environment variable LOGPROXY_ROTATION_SIZE is set, rotation-size will take this value\n  - If the environment variable LOGPROXY_ROTATION_SIZE is not set, rotation-size will take the default value 104857600\n";
+    gchar *description = "Optional environment variables to override defaults: \n    LOGPROXY_ROTATION_SIZE\n    LOGPROXY_ROTATION_TIME\n    LOGPROXY_ROTATION_SUFFIX\n    LOGPROXY_LOG_DIRECTORY\n    LOGPROXY_ROTATED_FILES\n    LOGPROXY_TIMESTAMPS\n\nExample for rotation-size option:\n- If log_proxy is run with the option --rotation-size on the command line, rotation-size will take the provided value\n- If the option --rotation-size is not provided on command line :\n  - If the environment variable LOGPROXY_ROTATION_SIZE is set, rotation-size will take this value\n  - If the environment variable LOGPROXY_ROTATION_SIZE is not set, rotation-size will take the default value 104857600\n";
     g_option_context_set_description(context, description);
     if (!g_option_context_parse(context, &argc, &argv, NULL)) {
         g_print("%s", g_option_context_get_help(context, TRUE, NULL));

--- a/src/log_proxy_wrapper.c
+++ b/src/log_proxy_wrapper.c
@@ -64,7 +64,7 @@ void spawn_logproxy_async(const gchar *fifo_path, const gchar *log_path) {
     if (use_locks) {
         use_locks_str = "--use-locks";
     }
-    gchar *cli = g_strdup_printf("log_proxy -s %li -t %li -S \"%s\" -n %i %s -r -f \"%s\" \"%s\"", rotation_size, rotation_time, rotation_suffix, rotated_files, use_locks_str, fifo_path, log_path);
+    gchar *cli = g_strdup_printf("log_proxy -s %li -t %li -S \"%s\" -T \"%s\" -n %i %s -r -f \"%s\" \"%s\"", rotation_size, rotation_time, rotation_suffix, timestamp_prefix, rotated_files, use_locks_str, fifo_path, log_path);
     gboolean spawn_res = g_spawn_command_line_async(cli, NULL);
     if (spawn_res == FALSE) {
         g_critical("can't spawn %s => exit", cli);

--- a/src/options.h
+++ b/src/options.h
@@ -10,6 +10,7 @@ static gchar *log_file = NULL;
 static glong rotation_size = -1;
 static glong rotation_time = -1;
 static gchar *rotation_suffix = NULL;
+static gchar *timestamp_prefix = NULL;
 static gchar *log_directory = NULL;
 static gchar *chmod_str = NULL;
 static gchar *chown_str = NULL;
@@ -70,6 +71,16 @@ void set_default_values_from_env()
         }
     }
 
+    if ( timestamp_prefix ==  NULL ) {
+        env_val = g_getenv("LOGPROXY_TIMESTAMPS");
+        if ( env_val != NULL ) {
+            timestamp_prefix = (gchar *)env_val;
+        }
+    }
+    if ( timestamp_prefix !=  NULL && strlen(timestamp_prefix) == 0 ) {
+        timestamp_prefix = NULL;
+    }
+
     if ( log_directory ==  NULL ) {
         env_val = g_getenv("LOGPROXY_LOG_DIRECTORY");
         if ( env_val != NULL ) {
@@ -94,6 +105,7 @@ static GOptionEntry entries[] = {
     { "rotation-suffix", 'S', 0, G_OPTION_ARG_STRING, &rotation_suffix, "strftime based suffix to append to rotated log files (default: content of environment variable LOGPROXY_ROTATION_SUFFIX or .%%Y%%m%%d%%H%%M%%S)", NULL },
     { "log-directory", 'd', 0, G_OPTION_ARG_STRING, &log_directory, "directory to store log files (default: content of environment variable LOGPROXY_LOG_DIRECTORY or current directory), directory is created if missing", NULL },
     { "rotated-files", 'n', 0, G_OPTION_ARG_INT, &rotated_files, "maximum number of rotated files to keep including main one (0 => no cleaning, default: content of environment variable LOGPROXY_ROTATED_FILES or 5)", NULL },
+    { "timestamps", 'T', 0, G_OPTION_ARG_STRING, &timestamp_prefix, "strftime prefix to prepend to every output line (default: content of environment variable LOGPROXY_TIMESTAMPS or none)", NULL },
     { "chmod", 'c', 0, G_OPTION_ARG_STRING, &chmod_str, "if set, chmod the logfile to this value, '0700' for example (default: content of environment variable LOGPROXY_CHMOD or NULL)", NULL },
     { "chown", 'o', 0, G_OPTION_ARG_STRING, &chown_str, "if set, try (if you don't have sufficient privileges, it will fail silently) to change the owner of the logfile to the given user value", NULL },
     { "chgrp", 'g', 0, G_OPTION_ARG_STRING, &chgrp_str, "if set, try (if you don't have sufficient privileges, it will fail silently) to change the group of the logfile to the given group value", NULL },

--- a/src/out.h
+++ b/src/out.h
@@ -3,7 +3,7 @@
 
 #include <glib.h>
 
-void init_output_channel(const gchar *log_file, gboolean use_locks, gboolean force_control_file, const gchar *chmod_str, const gchar *chown_str, const gchar *chgrp_str);
+void init_output_channel(const gchar *log_file, gboolean use_locks, gboolean force_control_file, const gchar *chmod_str, const gchar *chown_str, const gchar *chgrp_str, const gchar *timestamp_prefix);
 void destroy_output_channel();
 gboolean write_output_channel(GString *buffer);
 glong get_output_channel_age();

--- a/src/util.c
+++ b/src/util.c
@@ -116,6 +116,26 @@ gchar *compute_strftime_suffix(const gchar *str, const gchar *strftime_suffix) {
 }
 
 /**
+ * Format current timestamp prefix to prepend to a log line.
+ *
+ * @param strftime_prefix format with strftime placeholders to expand with current time.
+ * @return newly allocated string (free it with g_free) with the current timestamp prefix.
+ */
+gchar *compute_timestamp_prefix(const gchar *strftime_prefix) {
+    time_t t;
+    struct tm *tmp;
+    t = time(NULL);
+    tmp = localtime(&t);
+    g_assert(tmp != NULL);
+    char outstr[100];
+    if (strftime(outstr, sizeof(outstr), strftime_prefix, tmp) == 0) {
+        g_critical("problem with strftime on %s", strftime_prefix);
+        return NULL;
+    }
+    return g_strdup(outstr);
+}
+
+/**
  * Compute absolute file path from directory path and file name
  *
  * @param directory absolute or relative directory path

--- a/src/util.h
+++ b/src/util.h
@@ -7,6 +7,7 @@
 glong get_file_size(const gchar *file_path);
 glong get_current_timestamp();
 gchar *compute_strftime_suffix(const gchar *str, const gchar *strftime_suffix);
+gchar *compute_timestamp_prefix(const gchar *strftime_prefix);
 gchar *get_unique_hexa_identifier();
 glong get_file_inode(const gchar *file_path);
 glong get_fd_inode(int fd);


### PR DESCRIPTION
Might work to address `[ ] option to add a timestamp before each log line` in the README.
Not sure if it's the best way to do it, but was easy enough to add this way, to address my own use-case.
Feel free to merge with any kind of edits and tweaks, preserving commit/attribution does not matter to me at all.

Thanks for making this small tool.
It's especially useful in modern non-shell invocations with a proper wrapper mode and configuration via env vars.
