### PR TITLE
fix: pass -d/--log-directory command-line option from wrapper to logger process

### DIFF
--- a/src/log_proxy_wrapper.c
+++ b/src/log_proxy_wrapper.c
@@ -64,7 +64,7 @@ void spawn_logproxy_async(const gchar *fifo_path, const gchar *log_path) {
     if (use_locks) {
         use_locks_str = "--use-locks";
     }
-    gchar *cli = g_strdup_printf("log_proxy -s %li -t %li -S \"%s\" -n %i %s -r -f \"%s\" \"%s\"", rotation_size, rotation_time, rotation_suffix, rotated_files, use_locks_str, fifo_path, log_path);
+    gchar *cli = g_strdup_printf("log_proxy -s %li -t %li -S \"%s\" -d \"%s\" -n %i %s -r -f \"%s\" \"%s\"", rotation_size, rotation_time, rotation_suffix, log_directory, rotated_files, use_locks_str, fifo_path, log_path);
     gboolean spawn_res = g_spawn_command_line_async(cli, NULL);
     if (spawn_res == FALSE) {
         g_critical("can't spawn %s => exit", cli);


### PR DESCRIPTION
Seem to be a simple oversight.
Feel free to fix in a different way or treat as an issue indication, preserving commit/attribution does not matter to me at all.
