### PR TITLE
fix: build log_proxy command in wrapper as an argv array, don't use gshell parser

### DIFF
--- a/src/log_proxy.c
+++ b/src/log_proxy.c
@@ -228,7 +228,6 @@ int main(int argc, char *argv[])
     signal(SIGTERM, signal_handler);
     signal(SIGINT, signal_handler);
     set_default_values_from_env();
-    if ( strcmp( timestamp_prefix, "(null)" ) == 0 ) timestamp_prefix = NULL;
     log_file = compute_file_path(log_directory, argv[1]);
     // Create log directory if not existing
     gchar *log_dir = g_path_get_dirname(log_file);


### PR DESCRIPTION
This should fix passing `-T "(null)"` to log_proxy introduced by #35 in a hopefully slightly more obvious/cleaner way, and fix #37.

g_spawn_command_line_async() was replaced by g_spawn_async(), so that instead of earlier workflow of:

- sprintf-template a command line of arguments.
- Run g_spawn_command_line_async on it.
- Which runs g_shell_parse_argv to parse command line of arguments to `gchar **argv`.
- Run g_spawn_async with this argv.

It's just "build argv, run it with g_spawn_async", which eliminates unnecessary template-and-parse-it-back round-trip, and fixes string-escaping issues introduced by it cleanly.

Alternative can be to build a dynamic string, using g_shell_quote where string arguments are passed-through, but that seems unnecessary when it's just immediately parsed back to argv array anyway, and more error-prone in general.

Also removed `glib/*` component includes at the top, as these are redundant with `#include <glib.h>` which loads all of them, and are insufficient/incorrect otherwise anyway.
