### PR TITLE
fix: cleanup glib includes, add some missing libc ones

### DIFF
--- a/src/control.c
+++ b/src/control.c
@@ -1,5 +1,4 @@
 #include <glib.h>
-#include <glib/gstdio.h>
 #include <fcntl.h>
 #include <sys/file.h>
 #include <unistd.h>

--- a/src/log_proxy.c
+++ b/src/log_proxy.c
@@ -1,6 +1,5 @@
 #include <glib.h>
 #include <glib/gstdio.h>
-#include <glib/gprintf.h>
 #include <locale.h>
 #include <sys/file.h>
 #include <stdlib.h>

--- a/src/out.c
+++ b/src/out.c
@@ -1,8 +1,7 @@
 #include <glib.h>
-#include <glib/gprintf.h>
-#include <glib/gstdio.h>
 #include <locale.h>
 #include <sys/file.h>
+#include <sys/stat.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>

--- a/src/test_log_proxy.c
+++ b/src/test_log_proxy.c
@@ -1,6 +1,5 @@
 #include <glib.h>
 #include <glib/gstdio.h>
-#include <glib/gi18n.h>
 #include <fcntl.h>
 #include <locale.h>
 #include <string.h>

--- a/src/util.c
+++ b/src/util.c
@@ -3,6 +3,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <stdio.h>
 #include <sys/types.h>
 #include <pwd.h>
 #include <grp.h>


### PR DESCRIPTION
As mentioned at the end of https://github.com/metwork-framework/log_proxy/pull/38#issue-2125875743 , glib.h includes all of its basic components already - https://github.com/GNOME/glib/blob/main/glib/glib.h
While `glib/gprintf.h` in particular doesn't seem to be used anywhere - https://github.com/GNOME/glib/blob/main/glib/gprintf.h

So thought to apply same cleanup to all other .c files for consistency.
Couple of these unused includes pull in libc headers, which I've added directly instead.

Should neither require nor conflict with #38.
