### PR TITLE
perf: write out log line with time-prefix as one string to avoid holding locks

### DIFF
--- a/src/out.c
+++ b/src/out.c
@@ -93,24 +93,20 @@ gboolean write_output_channel(GString *buffer) {
     GIOStatus write_status;
     GError *error = NULL;
     gsize written;
-    gsize written_timestamp = 0;
+
+    if ( _timestamp_prefix != NULL ) {
+        GDateTime *dt = g_date_time_new_now_local();
+        gchar *prefix = g_date_time_format(dt, _timestamp_prefix);
+        g_string_prepend(buffer, prefix);
+        g_free(prefix);
+        g_date_time_unref(dt);
+    }
+
     while (TRUE) {
         if (_use_locks) {
             int res = flock(g_io_channel_unix_get_fd(_out_channel), LOCK_EX);
             if (res < 0) {
                 continue;
-            }
-        }
-
-        if ( _timestamp_prefix != NULL && written_timestamp == 0 ) {
-            gchar *timestamp = compute_timestamp_prefix(_timestamp_prefix);
-            if ( timestamp != NULL ) {
-                write_status = g_io_channel_write_chars(_out_channel, timestamp,
-                        strlen(timestamp), &written_timestamp, &error);
-                g_free(timestamp);
-                if (write_status == G_IO_STATUS_AGAIN) {
-                    continue;
-                }
             }
         }
 

--- a/src/util.c
+++ b/src/util.c
@@ -116,26 +116,6 @@ gchar *compute_strftime_suffix(const gchar *str, const gchar *strftime_suffix) {
 }
 
 /**
- * Format current timestamp prefix to prepend to a log line.
- *
- * @param strftime_prefix format with strftime placeholders to expand with current time.
- * @return newly allocated string (free it with g_free) with the current timestamp prefix.
- */
-gchar *compute_timestamp_prefix(const gchar *strftime_prefix) {
-    time_t t;
-    struct tm *tmp;
-    t = time(NULL);
-    tmp = localtime(&t);
-    g_assert(tmp != NULL);
-    char outstr[100];
-    if (strftime(outstr, sizeof(outstr), strftime_prefix, tmp) == 0) {
-        g_critical("problem with strftime on %s", strftime_prefix);
-        return NULL;
-    }
-    return g_strdup(outstr);
-}
-
-/**
  * Compute absolute file path from directory path and file name
  *
  * @param directory absolute or relative directory path

--- a/src/util.h
+++ b/src/util.h
@@ -7,7 +7,6 @@
 glong get_file_size(const gchar *file_path);
 glong get_current_timestamp();
 gchar *compute_strftime_suffix(const gchar *str, const gchar *strftime_suffix);
-gchar *compute_timestamp_prefix(const gchar *strftime_prefix);
 gchar *get_unique_hexa_identifier();
 glong get_file_inode(const gchar *file_path);
 glong get_fd_inode(int fd);


### PR DESCRIPTION
Earlier implementation in #35 can loop while holding the lock, which is not a good idea, and composing prefix+line into one GString is simpler anyway.
Using glib datetime and string formatting also allows to simplify implementation.
