### PR TITLE
fix: print more descriptive error for strftime() failure on timestamp-prefix

### DIFF
--- a/src/out.c
+++ b/src/out.c
@@ -96,9 +96,13 @@ gboolean write_output_channel(GString *buffer) {
     if ( _timestamp_prefix != NULL ) {
         GDateTime *dt = g_date_time_new_now_local();
         gchar *prefix = g_date_time_format(dt, _timestamp_prefix);
-        g_string_prepend(buffer, prefix);
-        g_free(prefix);
         g_date_time_unref(dt);
+        if ( prefix != NULL ) {
+            g_string_prepend(buffer, prefix);
+            g_free(prefix);
+        } else {
+            g_critical("strftime failed for timestamp-prefix: %s", _timestamp_prefix);
+        }
     }
 
     while (TRUE) {


### PR DESCRIPTION
Sorry for not thinking of it in #40, but this should fix non-descriptive something-about-assert-NULL error for bad timestamp-prefix format to something like this:
```
(log_proxy:269749): log_proxy-CRITICAL **: 17:37:58.678: strftime failed for timestamp-prefix: %
```
A relatively minor fix, I think.