### PR TITLE
fix: add more examples and correct some confusing wording in cli options' descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,13 +110,13 @@ Help Options:
   -h, --help                Show help options
 
 Application Options:
-  -s, --rotation-size       maximum size (in bytes) for a log file before rotation (0 => no maximum, default: content of environment variable LOGPROXY_ROTATION_SIZE or 104857600 (100MB))
-  -t, --rotation-time       maximum lifetime (in seconds) for a log file before rotation (0 => no maximum, default: content of environment variable LOGPROXY_ROTATION_TIME or 86400 (24H))
-  -S, --rotation-suffix     strftime based suffix to append to rotated log files (default: content of environment variable LOGPROXY_ROTATION_SUFFIX or .%%Y%%m%%d%%H%%M%%S)
+  -s, --rotation-size       maximum size (in bytes) for a log file before rotation (0 => no maximum, default: content of environment variable LOGPROXY_ROTATION_SIZE or 104857600 = 100MB)
+  -t, --rotation-time       maximum lifetime (in seconds) for a log file before rotation (0 => no maximum, default: content of environment variable LOGPROXY_ROTATION_TIME or 86400 = 24 hours)
+  -S, --rotation-suffix     strftime based suffix to append to rotated log files (default: content of environment variable LOGPROXY_ROTATION_SUFFIX or .%Y%m%d%H%M%S)
   -d, --log-directory       directory to store log files (default: content of environment variable LOGPROXY_LOG_DIRECTORY or current directory), directory is created if missing
   -n, --rotated-files       maximum number of rotated files to keep including main one (0 => no cleaning, default: content of environment variable LOGPROXY_ROTATED_FILES or 5)
-  -T, --timestamps          strftime prefix to prepend to every output line (default: content of environment variable LOGPROXY_TIMESTAMPS or none)
-  -c, --chmod               if set, chmod the logfile to this value, '0700' for example (default: content of environment variable LOGPROXY_CHMOD or NULL)
+  -T, --timestamps          strftime prefix to prepend to every output line, for example '[%F %T] ' (default: content of environment variable LOGPROXY_TIMESTAMPS or none)
+  -c, --chmod               if set, change mode of log files to this octal value, '0600' for example (default: content of environment variable LOGPROXY_CHMOD or don't change mode)
   -o, --chown               if set, try (if you don't have sufficient privileges, it will fail silently) to change the owner of the logfile to the given user value
   -g, --chgrp               if set, try (if you don't have sufficient privileges, it will fail silently) to change the group of the logfile to the given group value
   -m, --use-locks           use locks to append to main log file (useful if several process writes to the same file)
@@ -155,13 +155,13 @@ Help Options:
   -h, --help                Show help options
 
 Application Options:
-  -s, --rotation-size       maximum size (in bytes) for a log file before rotation (0 => no maximum, default: content of environment variable LOGPROXY_ROTATION_SIZE or 104857600 (100MB))
-  -t, --rotation-time       maximum lifetime (in seconds) for a log file before rotation (0 => no maximum, default: content of environment variable LOGPROXY_ROTATION_TIME or 86400 (24H))
-  -S, --rotation-suffix     strftime based suffix to append to rotated log files (default: content of environment variable LOGPROXY_ROTATION_SUFFIX or .%%Y%%m%%d%%H%%M%%S)
+  -s, --rotation-size       maximum size (in bytes) for a log file before rotation (0 => no maximum, default: content of environment variable LOGPROXY_ROTATION_SIZE or 104857600 = 100MB)
+  -t, --rotation-time       maximum lifetime (in seconds) for a log file before rotation (0 => no maximum, default: content of environment variable LOGPROXY_ROTATION_TIME or 86400 = 24 hours)
+  -S, --rotation-suffix     strftime based suffix to append to rotated log files (default: content of environment variable LOGPROXY_ROTATION_SUFFIX or .%Y%m%d%H%M%S)
   -d, --log-directory       directory to store log files (default: content of environment variable LOGPROXY_LOG_DIRECTORY or current directory), directory is created if missing
   -n, --rotated-files       maximum number of rotated files to keep including main one (0 => no cleaning, default: content of environment variable LOGPROXY_ROTATED_FILES or 5)
-  -T, --timestamps          strftime prefix to prepend to every output line (default: content of environment variable LOGPROXY_TIMESTAMPS or none)
-  -c, --chmod               if set, chmod the logfile to this value, '0700' for example (default: content of environment variable LOGPROXY_CHMOD or NULL)
+  -T, --timestamps          strftime prefix to prepend to every output line, for example '[%F %T] ' (default: content of environment variable LOGPROXY_TIMESTAMPS or none)
+  -c, --chmod               if set, change mode of log files to this octal value, '0600' for example (default: content of environment variable LOGPROXY_CHMOD or don't change mode)
   -o, --chown               if set, try (if you don't have sufficient privileges, it will fail silently) to change the owner of the logfile to the given user value
   -g, --chgrp               if set, try (if you don't have sufficient privileges, it will fail silently) to change the group of the logfile to the given group value
   -m, --use-locks           use locks to append to main log file (useful if several process writes to the same file)

--- a/src/options.h
+++ b/src/options.h
@@ -101,13 +101,13 @@ void set_default_values_from_env()
 }
 
 static GOptionEntry entries[] = {
-    { "rotation-size", 's', 0, G_OPTION_ARG_INT64, &rotation_size, "maximum size (in bytes) for a log file before rotation (0 => no maximum, default: content of environment variable LOGPROXY_ROTATION_SIZE or 104857600 (100MB))", NULL },
-    { "rotation-time", 't', 0, G_OPTION_ARG_INT64, &rotation_time, "maximum lifetime (in seconds) for a log file before rotation (0 => no maximum, default: content of environment variable LOGPROXY_ROTATION_TIME or 86400 (24H))", NULL },
-    { "rotation-suffix", 'S', 0, G_OPTION_ARG_STRING, &rotation_suffix, "strftime based suffix to append to rotated log files (default: content of environment variable LOGPROXY_ROTATION_SUFFIX or .%%Y%%m%%d%%H%%M%%S)", NULL },
+    { "rotation-size", 's', 0, G_OPTION_ARG_INT64, &rotation_size, "maximum size (in bytes) for a log file before rotation (0 => no maximum, default: content of environment variable LOGPROXY_ROTATION_SIZE or 104857600 = 100MB)", NULL },
+    { "rotation-time", 't', 0, G_OPTION_ARG_INT64, &rotation_time, "maximum lifetime (in seconds) for a log file before rotation (0 => no maximum, default: content of environment variable LOGPROXY_ROTATION_TIME or 86400 = 24 hours)", NULL },
+    { "rotation-suffix", 'S', 0, G_OPTION_ARG_STRING, &rotation_suffix, "strftime based suffix to append to rotated log files (default: content of environment variable LOGPROXY_ROTATION_SUFFIX or .%Y%m%d%H%M%S)", NULL },
     { "log-directory", 'd', 0, G_OPTION_ARG_STRING, &log_directory, "directory to store log files (default: content of environment variable LOGPROXY_LOG_DIRECTORY or current directory), directory is created if missing", NULL },
     { "rotated-files", 'n', 0, G_OPTION_ARG_INT, &rotated_files, "maximum number of rotated files to keep including main one (0 => no cleaning, default: content of environment variable LOGPROXY_ROTATED_FILES or 5)", NULL },
-    { "timestamps", 'T', 0, G_OPTION_ARG_STRING, &timestamp_prefix, "strftime prefix to prepend to every output line (default: content of environment variable LOGPROXY_TIMESTAMPS or none)", NULL },
-    { "chmod", 'c', 0, G_OPTION_ARG_STRING, &chmod_str, "if set, chmod the logfile to this value, '0700' for example (default: content of environment variable LOGPROXY_CHMOD or NULL)", NULL },
+    { "timestamps", 'T', 0, G_OPTION_ARG_STRING, &timestamp_prefix, "strftime prefix to prepend to every output line, for example '[%F %T] ' (default: content of environment variable LOGPROXY_TIMESTAMPS or none)", NULL },
+    { "chmod", 'c', 0, G_OPTION_ARG_STRING, &chmod_str, "if set, change mode of log files to this octal value, '0600' for example (default: content of environment variable LOGPROXY_CHMOD or don't change mode)", NULL },
     { "chown", 'o', 0, G_OPTION_ARG_STRING, &chown_str, "if set, try (if you don't have sufficient privileges, it will fail silently) to change the owner of the logfile to the given user value", NULL },
     { "chgrp", 'g', 0, G_OPTION_ARG_STRING, &chgrp_str, "if set, try (if you don't have sufficient privileges, it will fail silently) to change the group of the logfile to the given group value", NULL },
     { "use-locks", 'm', 0, G_OPTION_ARG_NONE, &use_locks, "use locks to append to main log file (useful if several process writes to the same file)", NULL },


### PR DESCRIPTION
As fixing -h/--help output in README file was mentioned in other PR, couple things in option descriptions did jump out to me as I skimmed over them earlier, and thought it'd be faster to propose changes rather than describe them.
Feel free to pick/commit couple ones that make sense and discard the rest, as I'm not a writer of any kind, so what do I know.

E.g. chmod option did bother me in particular:

- '0700' is a bad example - log files should not be made executable, pretty much ever, and people tend to copy bad examples without understanding, noticing or just giving it enough thought.

- "chmod the logfile to this value" -> "change file mode" since chmod isn't a common verb afaik.

- "or NULL" - raw C defaults probably shouldn't be documented like that :)

And so on, though obviously nitpicks, since imo having basically any description does 99% of the job as it is.
